### PR TITLE
Fix exists on path

### DIFF
--- a/src/bin/iso2god.rs
+++ b/src/bin/iso2god.rs
@@ -175,7 +175,7 @@ fn main() -> Result<(), Error> {
 }
 
 fn ensure_empty_dir(path: &Path) -> Result<(), Error> {
-    if fs::exists(path)? {
+    if path.exists() {
         fs::remove_dir_all(path)?;
     };
     fs::create_dir_all(path)?;


### PR DESCRIPTION
I tried to compile on M1 macbook, there is an issue with the fs::exists method, it seems it was removed. So instead I propose to use path.exists() method.