### PR TITLE
fix with_execution_info() writing ASCII digits instead of plain byte values

### DIFF
--- a/src/god/con_header.rs
+++ b/src/god/con_header.rs
@@ -67,18 +67,18 @@ impl ConHeaderBuilder {
 
         // this code writes plain bytes:
 
-        // cursor.write_u8(exe_info.platform).unwrap();
-        // cursor.write_u8(exe_info.executable_type).unwrap();
-        // cursor.write_u8(exe_info.disc_number).unwrap();
-        // cursor.write_u8(exe_info.disc_count).unwrap();
+        cursor.write_u8(exe_info.platform).unwrap();
+        cursor.write_u8(exe_info.executable_type).unwrap();
+        cursor.write_u8(exe_info.disc_number).unwrap();
+        cursor.write_u8(exe_info.disc_count).unwrap();
 
         // this code writes ASCII:
 
-        let ascii_0 = '0' as u8;
-        cursor.write_u8(exe_info.platform + ascii_0).unwrap();
-        cursor.write_u8(exe_info.executable_type + ascii_0).unwrap();
-        cursor.write_u8(exe_info.disc_number + ascii_0).unwrap();
-        cursor.write_u8(exe_info.disc_count + ascii_0).unwrap();
+        //let ascii_0 = '0' as u8;
+        //cursor.write_u8(exe_info.platform + ascii_0).unwrap();
+        //cursor.write_u8(exe_info.executable_type + ascii_0).unwrap();
+        //cursor.write_u8(exe_info.disc_number + ascii_0).unwrap();
+        //cursor.write_u8(exe_info.disc_count + ascii_0).unwrap();
 
         cursor.seek(SeekFrom::Start(0x0360)).unwrap();
         cursor.write_all(&exe_info.title_id).unwrap();

--- a/src/god/con_header.rs
+++ b/src/god/con_header.rs
@@ -62,23 +62,10 @@ impl ConHeaderBuilder {
 
         cursor.seek(SeekFrom::Start(0x0364)).unwrap();
 
-        // idk why, but the original code writes these as ASCII?
-        // TODO: is that a bug
-
-        // this code writes plain bytes:
-
         cursor.write_u8(exe_info.platform).unwrap();
         cursor.write_u8(exe_info.executable_type).unwrap();
         cursor.write_u8(exe_info.disc_number).unwrap();
         cursor.write_u8(exe_info.disc_count).unwrap();
-
-        // this code writes ASCII:
-
-        //let ascii_0 = '0' as u8;
-        //cursor.write_u8(exe_info.platform + ascii_0).unwrap();
-        //cursor.write_u8(exe_info.executable_type + ascii_0).unwrap();
-        //cursor.write_u8(exe_info.disc_number + ascii_0).unwrap();
-        //cursor.write_u8(exe_info.disc_count + ascii_0).unwrap();
 
         cursor.seek(SeekFrom::Start(0x0360)).unwrap();
         cursor.write_all(&exe_info.title_id).unwrap();


### PR DESCRIPTION
Aurora expects this metadata as bytes, not ASCII.