### PR TITLE
Add support for OG Xbox Images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,12 +450,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,7 +624,6 @@ dependencies = [
  "bitflags",
  "byteorder",
  "clap",
- "hex",
  "num",
  "num_enum",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ anyhow = { version = "1.0.86", features = ["backtrace"] }
 bitflags = "2.6.0"
 byteorder = "1.5.0"
 clap = { version = "4.5.9", features = ["derive"] }
-hex = "0.4.3"
 num = "0.4.3"
 num_enum = "0.7.2"
 sha1 = "0.10.6"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # iso2god-rs
-A tool to convert Xbox 360 ISOs into a Games-On-Demand file format
+A tool to convert Xbox 360 and original Xbox ISOs into an Xbox 360 compatible Games-On-Demand file format
 
 This is an optimized rewrite of https://github.com/eliecharra/iso2god-cli, with a few extra features.
 
@@ -7,7 +7,7 @@ This is an optimized rewrite of https://github.com/eliecharra/iso2god-cli, with 
 Usage: iso2god [OPTIONS] <SOURCE_ISO> <DEST_DIR>
 
 Arguments:
-  <SOURCE_ISO>  Xbox 360 ISO file to convert
+  <SOURCE_ISO>  ISO file to convert
   <DEST_DIR>    A folder to write resulting GOD files to
 
 Options:

--- a/examples/game_title/main.rs
+++ b/examples/game_title/main.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Error};
 use clap::{command, Parser};
-use hex;
 
 use iso2god::game_list;
 
@@ -25,16 +24,14 @@ struct Cli {
 fn main() -> Result<(), Error> {
     let args = Cli::parse();
 
-    let title_id: [u8; 4] = hex::decode(&args.title_id)?
-        .try_into()
-        .map_err(|_| Error::msg("invalid title ID"))?;
+    let title_id = u32::from_str_radix("4D530064", 16)?;
 
     match args.source {
         Source::BuiltIn => {
             println!("querying the built-in DB for title ID {}", args.title_id);
 
             if let Some(name) = game_list::find_title_by_id(title_id) {
-                let title_id = hex::encode_upper(title_id);
+                let title_id = format!("{:08X}", title_id);
                 println!("Title ID: {title_id}");
                 println!("    Name: {name}");
             } else {
@@ -48,7 +45,7 @@ fn main() -> Result<(), Error> {
             let client = unity::Client::new().context("error creating XboxUnity client")?;
 
             let unity_title_info = client
-                .find_xbox_360_title_id(&title_id)
+                .find_xbox_360_title_id(title_id)
                 .context("error querying XboxUnity")?;
 
             if let Some(unity_title_info) = &unity_title_info {

--- a/examples/game_title/unity.rs
+++ b/examples/game_title/unity.rs
@@ -8,8 +8,6 @@ use anyhow::Error;
 
 use std::time::Duration;
 
-use hex;
-
 use std::fmt;
 
 #[derive(Deserialize)]
@@ -131,8 +129,8 @@ impl Client {
         Ok(response)
     }
 
-    pub fn find_xbox_360_title_id(&self, title_id: &[u8; 4]) -> Result<Option<Title>, Error> {
-        let title_id = hex::encode_upper(title_id);
+    pub fn find_xbox_360_title_id(&self, title_id: u32) -> Result<Option<Title>, Error> {
+        let title_id = format!("{:08X}", title_id);
 
         let title_list = self.search(&title_id)?;
 

--- a/examples/list_files.rs
+++ b/examples/list_files.rs
@@ -13,7 +13,7 @@ use iso2god::iso;
 #[command(author, version, about, long_about = None)]
 #[command(color = clap::ColorChoice::Never)]
 struct Cli {
-    /// Xbox 360 ISO file
+    /// ISO file
     source_iso: PathBuf,
 }
 

--- a/src/bin/iso2god.rs
+++ b/src/bin/iso2god.rs
@@ -18,7 +18,7 @@ use iso2god::{game_list, god, iso};
 #[command(author, version, about, long_about = None)]
 #[command(color = clap::ColorChoice::Never)]
 struct Cli {
-    /// Xbox 360 ISO file to convert
+    /// ISO file to convert
     source_iso: PathBuf,
 
     /// A folder to write resulting GOD files to

--- a/src/executable/mod.rs
+++ b/src/executable/mod.rs
@@ -1,0 +1,107 @@
+use crate::god::ContentType;
+use crate::iso::IsoReader;
+use anyhow::{anyhow, Context, Error};
+use byteorder::{ReadBytesExt, BE, LE};
+use std::io::{Read, Seek, SeekFrom};
+
+pub mod xbe;
+pub mod xex;
+
+#[derive(Clone, Debug)]
+pub struct TitleExecutionInfo {
+    pub media_id: u32,
+    pub version: u32,
+    pub base_version: u32,
+    pub title_id: u32,
+    pub platform: u8,
+    pub executable_type: u8,
+    pub disc_number: u8,
+    pub disc_count: u8,
+}
+
+pub struct TitleInfo {
+    pub content_type: ContentType,
+    pub execution_info: TitleExecutionInfo,
+}
+
+impl TitleExecutionInfo {
+    pub fn from_xex<R: Read>(reader: &mut R) -> Result<TitleExecutionInfo, Error> {
+        Ok(TitleExecutionInfo {
+            media_id: reader.read_u32::<BE>()?,
+            version: reader.read_u32::<BE>()?,
+            base_version: reader.read_u32::<BE>()?,
+            title_id: reader.read_u32::<BE>()?,
+            platform: reader.read_u8()?,
+            executable_type: reader.read_u8()?,
+            disc_number: reader.read_u8()?,
+            disc_count: reader.read_u8()?,
+        })
+    }
+
+    pub fn from_xbe<R: Read + Seek>(reader: &mut R) -> Result<TitleExecutionInfo, Error> {
+        reader.seek(SeekFrom::Current(8))?;
+        let title_id = reader.read_u32::<LE>()?;
+
+        reader.seek(SeekFrom::Current(164))?;
+        let version = reader.read_u32::<LE>()?;
+
+        Ok(TitleExecutionInfo {
+            media_id: 0,
+            version,
+            base_version: 0,
+            title_id,
+            platform: 0,
+            executable_type: 0,
+            disc_number: 1,
+            disc_count: 1,
+        })
+    }
+}
+
+impl TitleInfo {
+    pub fn from_image<R: Read + Seek>(iso_image: &mut IsoReader<R>) -> Result<TitleInfo, Error> {
+        let content_type;
+        let mut executable;
+
+        match iso_image.get_entry(&"\\default.xex".into())? {
+            Some(entry) => {
+                executable = entry;
+                content_type = ContentType::GamesOnDemand;
+            }
+            None => {
+                executable = iso_image
+                    .get_entry(&"\\default.xbe".into())?
+                    .ok_or_else(|| anyhow!("no executable found in this image"))?;
+                content_type = ContentType::XboxOriginal;
+            }
+        }
+
+        let execution_info;
+
+        match content_type {
+            ContentType::GamesOnDemand => {
+                let default_xex_header =
+                    xex::XexHeader::read(&mut executable).context("error reading default.xex")?;
+
+                execution_info = default_xex_header
+                    .fields
+                    .execution_info
+                    .context("no execution info in default.xex header")?;
+            }
+            ContentType::XboxOriginal => {
+                let default_xbe_header =
+                    xbe::XbeHeader::read(&mut executable).context("error reading default.xbe")?;
+
+                execution_info = default_xbe_header
+                    .fields
+                    .execution_info
+                    .context("no execution info in default.xbe header")?;
+            }
+        }
+
+        Ok(TitleInfo {
+            content_type,
+            execution_info,
+        })
+    }
+}

--- a/src/executable/xbe.rs
+++ b/src/executable/xbe.rs
@@ -1,0 +1,54 @@
+use crate::executable::TitleExecutionInfo;
+use anyhow::{bail, Error};
+use byteorder::{ReadBytesExt, LE};
+use std::io::{Read, Seek, SeekFrom};
+
+pub struct XbeHeader {
+    // We only need these fields to get the cert address
+    pub dw_base_addr: u32,
+    pub dw_certificate_addr: u32,
+    pub fields: XbeHeaderFields,
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct XbeHeaderFields {
+    pub execution_info: Option<TitleExecutionInfo>,
+}
+
+impl XbeHeader {
+    pub fn read<R: Read + Seek>(reader: &mut R) -> Result<XbeHeader, Error> {
+        Self::check_magic_bytes(reader)?;
+
+        // Offset 0x0104
+        reader.seek(SeekFrom::Current(256))?;
+        let dw_base_addr = reader.read_u32::<LE>()?;
+
+        // Offset 0x0118
+        reader.seek(SeekFrom::Current(16))?;
+        let dw_certificate_addr = reader.read_u32::<LE>()?;
+
+        let offset = reader.stream_position()? - 284;
+        let cert_address = dw_certificate_addr - dw_base_addr;
+        reader.seek(SeekFrom::Start(offset + (cert_address as u64)))?;
+
+        let mut fields: XbeHeaderFields = Default::default();
+        fields.execution_info = Some(TitleExecutionInfo::from_xbe(reader)?);
+
+        Ok(XbeHeader {
+            dw_base_addr,
+            dw_certificate_addr,
+            fields,
+        })
+    }
+
+    fn check_magic_bytes<R: Read + Seek>(reader: &mut R) -> Result<(), Error> {
+        let mut magic_bytes = [0u8; 4];
+        reader.read_exact(&mut magic_bytes)?;
+
+        if &magic_bytes != b"XBEH" {
+            bail!("missing 'XBEH' magic bytes in XBE header");
+        }
+
+        Ok(())
+    }
+}

--- a/src/game_list/generate.bash
+++ b/src/game_list/generate.bash
@@ -8,9 +8,9 @@ cat <<'EOF'
 // Run `./generate.bash titles.jsonl mod.rs` to re-generate.
 
 
-pub fn find_title_by_id(title_id: [u8; 4]) -> Option<String> {
+pub fn find_title_by_id(title_id: u32) -> Option<String> {
     GAMES_BY_TITLE_ID
-        .binary_search_by_key(&u32::from_be_bytes(title_id), |x| x.0)
+        .binary_search_by_key(&title_id, |x| x.0)
         .ok()
         .map(|i| GAMES_BY_TITLE_ID[i].1.to_owned())
 }

--- a/src/game_list/mod.rs
+++ b/src/game_list/mod.rs
@@ -1,6 +1,7 @@
 // DO NOT EDIT; this file is auto-generated.
 // Run `./generate.bash titles.jsonl mod.rs` to re-generate.
 
+
 pub fn find_title_by_id(title_id: u32) -> Option<String> {
     GAMES_BY_TITLE_ID
         .binary_search_by_key(&title_id, |x| x.0)

--- a/src/game_list/mod.rs
+++ b/src/game_list/mod.rs
@@ -1,10 +1,9 @@
 // DO NOT EDIT; this file is auto-generated.
 // Run `./generate.bash titles.jsonl mod.rs` to re-generate.
 
-
-pub fn find_title_by_id(title_id: [u8; 4]) -> Option<String> {
+pub fn find_title_by_id(title_id: u32) -> Option<String> {
     GAMES_BY_TITLE_ID
-        .binary_search_by_key(&u32::from_be_bytes(title_id), |x| x.0)
+        .binary_search_by_key(&title_id, |x| x.0)
         .ok()
         .map(|i| GAMES_BY_TITLE_ID[i].1.to_owned())
 }

--- a/src/god/con_header.rs
+++ b/src/god/con_header.rs
@@ -4,7 +4,7 @@ use byteorder::{WriteBytesExt, BE, LE};
 
 use sha1::{Digest, Sha1};
 
-use crate::xex;
+use crate::executable::TitleExecutionInfo;
 
 const EMPTY_LIVE: &[u8] = include_bytes!("empty_live.bin");
 
@@ -57,7 +57,7 @@ impl ConHeaderBuilder {
         self
     }
 
-    pub fn with_execution_info(mut self, exe_info: &xex::XexExecutionInfo) -> Self {
+    pub fn with_execution_info(mut self, exe_info: &TitleExecutionInfo) -> Self {
         let mut cursor = Cursor::new(&mut self.buffer);
 
         cursor.seek(SeekFrom::Start(0x0364)).unwrap();
@@ -68,10 +68,10 @@ impl ConHeaderBuilder {
         cursor.write_u8(exe_info.disc_count).unwrap();
 
         cursor.seek(SeekFrom::Start(0x0360)).unwrap();
-        cursor.write_all(&exe_info.title_id).unwrap();
+        cursor.write_u32::<BE>(exe_info.title_id).unwrap();
 
         cursor.seek(SeekFrom::Start(0x0354)).unwrap();
-        cursor.write_all(&exe_info.media_id).unwrap();
+        cursor.write_u32::<BE>(exe_info.media_id).unwrap();
 
         self
     }

--- a/src/god/file_layout.rs
+++ b/src/god/file_layout.rs
@@ -1,21 +1,19 @@
 use std::path::{Path, PathBuf};
 
-use hex;
-
-use crate::xex;
+use crate::executable::TitleExecutionInfo;
 
 use super::*;
 
 pub struct FileLayout<'a> {
     base_path: &'a Path,
-    exe_info: &'a xex::XexExecutionInfo,
+    exe_info: &'a TitleExecutionInfo,
     content_type: ContentType,
 }
 
 impl<'a> FileLayout<'a> {
     pub fn new(
         base_path: &'a Path,
-        exe_info: &'a xex::XexExecutionInfo,
+        exe_info: &'a TitleExecutionInfo,
         content_type: ContentType,
     ) -> FileLayout<'a> {
         FileLayout {
@@ -26,7 +24,7 @@ impl<'a> FileLayout<'a> {
     }
 
     fn title_id_string(&self) -> String {
-        hex::encode_upper(self.exe_info.title_id)
+        format!("{:08X}", self.exe_info.title_id)
     }
 
     fn content_type_string(&self) -> String {
@@ -34,7 +32,14 @@ impl<'a> FileLayout<'a> {
     }
 
     fn media_id_string(&self) -> String {
-        hex::encode_upper(self.exe_info.media_id)
+        match self.content_type {
+            ContentType::GamesOnDemand => {
+                format!("{:08X}", self.exe_info.media_id)
+            }
+            ContentType::XboxOriginal => {
+                format!("{:08X}", self.exe_info.title_id)
+            }
+        }
     }
 
     pub fn data_dir_path(&self) -> PathBuf {

--- a/src/iso/iso_type.rs
+++ b/src/iso/iso_type.rs
@@ -6,16 +6,18 @@ use super::*;
 
 #[derive(Debug)]
 pub enum IsoType {
-    Gdf,
     Xgd3,
+    Xgd2,
+    Xgd1,
     Xsf,
 }
 
 impl IsoType {
     pub fn root_offset(&self) -> u64 {
         match self {
-            IsoType::Gdf => 0xfd90000,
             IsoType::Xgd3 => 0x2080000,
+            IsoType::Xgd2 => 0xfd90000,
+            IsoType::Xgd1 => 0x18300000,
             IsoType::Xsf => 0,
         }
     }
@@ -25,8 +27,12 @@ impl IsoType {
             return Ok(Some(IsoType::Xsf));
         }
 
-        if Self::check(reader, IsoType::Gdf)? {
-            return Ok(Some(IsoType::Gdf));
+        if Self::check(reader, IsoType::Xgd2)? {
+            return Ok(Some(IsoType::Xgd2));
+        }
+
+        if Self::check(reader, IsoType::Xgd1)? {
+            return Ok(Some(IsoType::Xgd1));
         }
 
         // original code had no extra check here, simply returning Xgd3 as fallback

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
+pub mod executable;
 pub mod game_list;
 pub mod god;
 pub mod iso;
-pub mod xex;


### PR DESCRIPTION
The original Iso2God had support for OG Xbox images, but this feature was removed in the CLI implementation. This PR aims to restore support for XBE executables, addressing issue #13.

The implementation checks for an XEX file inside the XDVDFS image first; if not found, it then searches for an XBE file.

This is a working, but still rough, WIP implementation of the concept. If you have any thoughts or suggestions on this feature, I'd be happy to hear them.