### PR TITLE
Very WIP: Build and sign NXE/"Installed Game" containers

### DIFF
--- a/src/bin/iso2god.rs
+++ b/src/bin/iso2god.rs
@@ -83,6 +83,7 @@ fn main() -> Result<(), Error> {
         match content_type {
             ContentType::GamesOnDemand => println!("    Type: Games on Demand"),
             ContentType::XboxOriginal => println!("    Type: Xbox Original"),
+            ContentType::InstalledGame => println!("    Type: NXE Installed Game"),
         }
     }
 
@@ -172,7 +173,7 @@ fn main() -> Result<(), Error> {
         con_header = con_header.with_game_title(&game_title);
     }
 
-    let con_header = con_header.finalize();
+    let con_header = con_header.finalize_with_fake_signature();
 
     let mut con_header_file = File::options()
         .write(true)

--- a/src/god/con_header.rs
+++ b/src/god/con_header.rs
@@ -14,6 +14,7 @@ pub struct ConHeaderBuilder {
 pub enum ContentType {
     GamesOnDemand = 0x7000,
     XboxOriginal = 0x5000,
+    InstalledGame = 0x4000,
 }
 
 impl ConHeaderBuilder {
@@ -103,13 +104,42 @@ impl ConHeaderBuilder {
         self
     }
 
-    pub fn finalize(mut self) -> Vec<u8> {
-        self.buffer[0x035b] = 0;
-        self.buffer[0x035f] = 0;
+    pub fn with_device_id(mut self, device_id: &[u8; 20]) -> Self {
+        self.write_bytes(0x03fd, device_id);
+        self
+    }
+
+    pub fn finalize_with_fake_signature(mut self) -> Vec<u8> {
+        self.write_u32_be(0x0000, 0x4C495645); // 'LIVE'
+
+        self.buffer[0x035b] = 0; // version
+        self.buffer[0x035f] = 0; // base version
         self.buffer[0x0391] = 0;
 
+        // digest = SVOD header start at 0x344 - eof
         let digest: [u8; 20] = Sha1::digest(&self.buffer[0x0344..(0x0344 + 0xacbc)]).into();
         self.write_bytes(0x032c, &digest);
+
+        self.buffer
+    }
+
+    pub fn finalize_with_console_cert(mut self, device_certificate: &[u8; 0x1A8], private_key: &[u8; 0x1D0]) -> Vec<u8> {
+        self.write_u32_be(0x0000, 0x434F4E20); // 'CON '
+
+        self.write_bytes(0x0004, device_certificate);
+
+        self.buffer[0x035b] = 0; // version
+        self.buffer[0x035f] = 0; // base version
+        self.buffer[0x0391] = 0;
+
+        // digest = SVOD header start at 0x344 - eof
+        let digest: [u8; 20] = Sha1::digest(&self.buffer[0x0344..(0x0344 + 0xacbc)]).into();
+        self.write_bytes(0x032c, &digest);
+
+        // signature digest = licence table - SVOD header start
+        let digest_to_sign: [u8; 20] = Sha1::digest(&self.buffer[0x22C..(0x22C + 0x114)]).into();
+
+        // TODO: Sign
 
         self.buffer
     }

--- a/src/god/file_layout.rs
+++ b/src/god/file_layout.rs
@@ -33,7 +33,7 @@ impl<'a> FileLayout<'a> {
 
     fn media_id_string(&self) -> String {
         match self.content_type {
-            ContentType::GamesOnDemand => {
+            ContentType::GamesOnDemand | ContentType::InstalledGame => {
                 format!("{:08X}", self.exe_info.media_id)
             }
             ContentType::XboxOriginal => {


### PR DESCRIPTION
Since we can dump keyvaults from most systems now, it's probably feasible to try to build "installed game" packages out of an ISO. These have to be made more carefully than regular GoD containers - the version/base version have to match the ones on the disc, the device ID has to match, maybe license flags have to be valid too, and it has to be signed with the keyvault for the console you're using.

The end goal would be to let you build these packages out of modified ISOs to do certain types of game mods (e.g. Guitar Hero II Deluxe), or to act as a replacement for discs that are scratched enough to be read by the OS, but too scratched to be functional or to install to the HDD.

The big part that needs doing currently is console signing, but I'd like input on how I'm doing things since I'm a Rust newbie. The private key is stored in the keyvault as a set of big-endian integers and need to be parsed in a way that'd make them useful to sign data with in the library. I see three options:
- The iso2god-rs library parses the keyvault and private key and just takes it in as a parameter in either the ConHeaderBuilder or the finalize function.
- The calling application parses the keyvault, then passes the console certificate and the private key as raw bytes to iso2god-rs which then parses it into an RsaPrivateKey struct.
- The calling application parses the keyvault and private key, then passes the certificate and a parsed RsaPrivateKey struct to the library.