### PR TITLE
Skip empty DirectoryEntry entries

### DIFF
--- a/src/iso/directory_table.rs
+++ b/src/iso/directory_table.rs
@@ -98,6 +98,11 @@ impl DirectoryEntry {
         let sector = reader.read_u32::<LE>()?;
         let size = reader.read_u32::<LE>()?;
 
+        // This entry is empty
+        if size == 0 {
+            return Ok(None);
+        }
+
         let attributes = DirectoryEntryAttributes::from_bits_truncate(reader.read_u8()?);
 
         let name_length = reader.read_u8()?;


### PR DESCRIPTION
Resolves #22 by skipping over empty `DirectoryEntry` entries, they are identified by checking their size against 0. In theory, empty entries would have a sector value of 0 too, but size is enough to properly identify them.

As most XISO unpacking tools skip these empty entries already, I'd say it's safe to assume compatibility hasn't been affected.

Tested with a full play-through of a Resident Evil ORC (US, EU) Redump verified copy.